### PR TITLE
Use WC_Product#get_title() for variation name. WooCommerce 2.6.14 doe…

### DIFF
--- a/includes/integration.php
+++ b/includes/integration.php
@@ -786,7 +786,7 @@ class Metrilo_Woo_Analytics_Integration extends WC_Integration {
     }
 
 		if(empty($variation_data['name'])) {
-			$variation_data['name'] = $variation_obj->get_name();
+			$variation_data['name'] = $variation_obj->get_title();
 		}
 
 		$variation_data['price'] = $this->object_property($variation_obj, 'variation', 'price');

--- a/includes/integration.php
+++ b/includes/integration.php
@@ -785,12 +785,15 @@ class Metrilo_Woo_Analytics_Integration extends WC_Integration {
       $variation_obj = new WC_Product_Variation($variation_id);
     }
 
-		if(empty($variation_data['name'])) {
-			$variation_data['name'] = $variation_obj->get_title();
-		}
-
 		$variation_data['price'] = $this->object_property($variation_obj, 'variation', 'price');
-		$variation_data['sku'] = $variation_obj->get_sku();
+
+		if($variation_obj) {
+			if(empty($variation_data['name'])) {
+				$variation_data['name'] = $variation_obj->get_title();
+			}
+
+			$variation_data['sku'] = $variation_obj->get_sku();
+		}
 
 		// return
 		return $variation_data;


### PR DESCRIPTION
…s not implement WC_Product#get_name()